### PR TITLE
history: ListAllMyHistory, ListHistory implemented

### DIFF
--- a/history.go
+++ b/history.go
@@ -1,0 +1,187 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/orijtech/otils"
+)
+
+type Status string
+
+type Trip struct {
+	// Status of the activity. As per API v1.2,
+	// it only return "completed" for now.
+	Status Status `json:"status,omitempty"`
+
+	// Length of activity in miles.
+	DistanceMiles float64 `json:"distance,omitempty"`
+
+	// UnixTimestamp of activity start time.
+	StartTimeUnix int64 `json:"start_time,omitempty"`
+
+	// UnixTimestamp of activity end time.
+	EndTimeUnix int64 `json:"end_time,omitempty"`
+
+	// The city in which this trip was initiated.
+	StartCity *Place `json:"start_city,omitempty"`
+
+	ProductID string `json:"product_id,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+}
+
+type Place struct {
+	// The latitude of the approximate city center.
+	Latitude float64 `json:"latitude,omitempty"`
+
+	Name string `json:"display_name,omitempty"`
+
+	// The longitude of the approximate city center.
+	Longitude float64 `json:"longitude,omitempty"`
+}
+
+type TripThread struct {
+	Trips  []*Trip `json:"history"`
+	Count  int64   `json:"count"`
+	Limit  int64   `json:"limit"`
+	Offset int64   `json:"offset"`
+}
+
+type TripHistoryRequest struct {
+	ThrottleDuration time.Duration `json:"-"`
+	LimitPerPage     int64         `json:"limit"`
+	MaxPages         int64         `json:"-"`
+	StartOffset      int64         `json:"offset"`
+}
+
+type TripThreadPage struct {
+	TripThread
+	Err        error
+	PageNumber uint64
+}
+
+const (
+	DefaultLimitPerPage = int64(50)
+	DefaultStartOffset  = int64(0)
+)
+
+func (treq *TripHistoryRequest) adjustPageParams() {
+	if treq.LimitPerPage <= 0 {
+		treq.LimitPerPage = DefaultLimitPerPage
+	}
+	if treq.StartOffset <= 0 {
+		treq.StartOffset = DefaultStartOffset
+	}
+}
+
+func (c *Client) ListAllMyHistory() (chan *TripThreadPage, chan<- bool, error) {
+	return c.ListHistory(nil)
+}
+
+func (c *Client) ListHistory(threq *TripHistoryRequest) (chan *TripThreadPage, chan<- bool, error) {
+	treq := new(TripHistoryRequest)
+	if threq != nil {
+		*treq = *threq
+	}
+
+	// Adjust the paging parameters since they'll be heavily used
+	treq.adjustPageParams()
+
+	requestedMaxPage := treq.MaxPages
+	pageNumberExceeds := func(pageNumber uint64) bool {
+		if requestedMaxPage <= 0 {
+			// No page limit requested at all here
+			return false
+		}
+
+		return pageNumber >= uint64(requestedMaxPage)
+	}
+
+	cancelChan := make(chan bool, 1)
+	historyChan := make(chan *TripThreadPage)
+	go func() {
+		defer close(historyChan)
+
+		throttleDuration := 150 * time.Millisecond
+		pageNumber := uint64(0)
+
+		canPage := true
+		for canPage {
+			ttp := new(TripThreadPage)
+			ttp.PageNumber = pageNumber
+
+			qv, err := otils.ToURLValues(treq)
+			if err != nil {
+				ttp.Err = err
+				historyChan <- ttp
+				return
+			}
+
+			fullURL := fmt.Sprintf("%s/history?%s", baseURL, qv.Encode())
+			req, err := http.NewRequest("GET", fullURL, nil)
+			if err != nil {
+				ttp.Err = err
+				historyChan <- ttp
+				return
+			}
+
+			slurp, _, err := c.doAuthAndHTTPReq(req)
+			if err != nil {
+				ttp.Err = err
+				historyChan <- ttp
+				return
+			}
+
+			if err := json.Unmarshal(slurp, ttp); err != nil {
+				ttp.Err = err
+				historyChan <- ttp
+				return
+			}
+
+			historyChan <- ttp
+
+			if ttp.Count <= 0 {
+				// No more items to page
+				return
+			}
+
+			select {
+			case <-cancelChan:
+				// The user has canceled the paging
+				canPage = false
+				return
+
+			case <-time.After(throttleDuration):
+				// Do nothing here, the throttle time expired.
+			}
+
+			// Now it is time to adjust the next offset accordingly with the remaining count
+
+			// Increment the page number as well
+			pageNumber += 1
+			if pageNumberExceeds(pageNumber) {
+				return
+			}
+
+			treq.StartOffset += treq.LimitPerPage
+		}
+	}()
+
+	return historyChan, cancelChan, nil
+}

--- a/uber_test.go
+++ b/uber_test.go
@@ -67,6 +67,24 @@ func TestListPaymentMethods(t *testing.T) {
 	}
 }
 
+func TestListHistory(t *testing.T) {
+	t.Skipf("Needs quite detailed data and intricate tests with paging")
+
+	// client, err := uber.NewClient(testToken1)
+	// if err != nil {
+ 	// 	t.Fatalf("initializing client; %v", err)
+	// }
+
+	// if err != nil {
+	// 	t.Fatalf("initializing client; %v", err)
+	// }
+
+	// testingRoundTripper := &tRoundTripper{route: listHistory}
+	// client.SetHTTPRoundTripper(testingRoundTripper)
+
+	// tests := [...]struct{}{}
+}
+
 func jsonSerialize(v interface{}) []byte {
 	blob, _ := json.Marshal(v)
 	return blob


### PR DESCRIPTION
Added methods to list one's history:
* ListHistory
* ListAllMyHistory

They support paging
that is cancelable at any time. See example_test.go.

For example, this is fully copy+pastable and then runnable example:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/uber"
)

func Example_client_ListAllMyHistory() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	pagesChan, cancelChan, err := client.ListAllMyHistory()
	if err != nil {
		log.Fatal(err)
	}

	for page := range pagesChan {
		if page.Err != nil {
			fmt.Printf("Page: #%d err: %v\n", page.PageNumber, page.Err)
			continue
		}

		fmt.Printf("Page: #%d\n\n", page.PageNumber)
		for i, trip := range page.Trips {
			startCity := trip.StartCity
			if startCity.Name == "Edmonton" {
				fmt.Printf("aha found the trip from Edmonton, canceling the rest!: %#v\n", trip)
				cancelChan <- true
				break
			}

			// Otherwise, continue listing
			fmt.Printf("Trip: #%d ==> %#v place: %#v\n", i, trip, startCity)
		}
	}
}
```

that will print out for me
```shell
aha found the trip from Edmonton, canceling the rest!:
&uber.Trip{Status:"completed", DistanceMiles:2.183555252, StartTimeUnix:1493768991, EndTimeUnix:1493769478, StartCity:(*uber.Place)(0xc42018c360), ProductID:"10e93f8e-0de2-4efe-ba04-b4618291686f", RequestID:"0618057f-137b-4d08-9838-395c6afda1be"}
```