### PR TITLE
profile: ApplyPromoCode, RetrieveProfile implemented

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -144,3 +144,31 @@ func Example_client_EstimatePrice() {
 		}
 	}
 }
+
+func Example_client_RetrieveMyProfile() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	myProfile, err := client.RetrieveMyProfile()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Here is my profile: %#v\n", myProfile)
+}
+
+func Example_client_ApplyPromoCode() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	appliedPromoCode, err := client.ApplyPromoCode("uberd340ue")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("AppliedPromoCode: %#v\n", appliedPromoCode)
+}

--- a/v1/profile.go
+++ b/v1/profile.go
@@ -1,0 +1,106 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type Profile struct {
+	// First name of the Uber user.
+	FirstName string `json:"first_name,omitempty"`
+
+	// Last name of the Uber user.
+	LastName string `json:"last_name,omitempty"`
+
+	// Email address of the Uber user.
+	Email string `json:"email,omitempty"`
+
+	// Image URL of the Uber user.
+	PictureURL string `json:"picture,omitempty"`
+
+	// Whether the user has confirmed their mobile number.
+	MobileVerified bool `json:"mobile_verified"`
+
+	// The promotion code for the user.
+	// Can be used for rewards when referring
+	// other users to Uber.
+	PromoCode string `json:"promo_code,omitempty"`
+
+	ID string `json:"uuid,omitempty"`
+}
+
+func (c *Client) RetrieveMyProfile() (*Profile, error) {
+	fullURL := fmt.Sprintf("%s/me", baseURL)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	slurp, _, err := c.doAuthAndHTTPReq(req)
+	if err != nil {
+		return nil, err
+	}
+	prof := new(Profile)
+	if err := json.Unmarshal(slurp, prof); err != nil {
+		return nil, err
+	}
+	return prof, nil
+}
+
+type PromoCode struct {
+	Description string `json:"description,omitempty"`
+	Code        string `json:"promo_code,omitempty"`
+}
+
+var errNilPromoCode = errors.New("expecting a non-empty promoCode")
+
+type PromoCodeRequest struct {
+	CodeToApply string `json:"applied_promotion_codes"`
+}
+
+func (c *Client) ApplyPromoCode(promoCode string) (*PromoCode, error) {
+	if promoCode == "" {
+		return nil, errNilPromoCode
+	}
+
+	pcReq := &PromoCodeRequest{
+		CodeToApply: promoCode,
+	}
+
+	blob, err := json.Marshal(pcReq)
+	if err != nil {
+		return nil, err
+	}
+	fullURL := fmt.Sprintf("%s/me", baseURL)
+	req, err := http.NewRequest("PATCH", fullURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+	slurp, _, err := c.doAuthAndHTTPReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	appliedPromoCode := new(PromoCode)
+	if err := json.Unmarshal(slurp, appliedPromoCode); err != nil {
+		return nil, err
+	}
+
+	return appliedPromoCode, nil
+}

--- a/v1/testdata/profile-TEST_TOKEN-1.json
+++ b/v1/testdata/profile-TEST_TOKEN-1.json
@@ -1,0 +1,10 @@
+{
+  "picture": "https://d1w2poirtb3as9.cloudfront.net/f3be498cb0bbf570aa3d.jpeg",
+  "first_name": "Uber",
+  "last_name": "Developer",
+  "uuid": "f4a416e3-6016-4623-8ec9-d5ee105a6e27",
+  "rider_id": "8OlTlUG1TyeAQf1JiBZZdkKxuSSOUwu2IkO0Hf9d2HV52Pm25A0NvsbmbnZr85tLVi-s8CckpBK8Eq0Nke4X-no3AcSHfeVh6J5O6LiQt5LsBZDSi4qyVUdSLeYDnTtirw==",
+  "email": "uberdevelopers@gmail.com",
+  "mobile_verified": true,
+  "promo_code": "uberd340ue"
+}

--- a/v1/testdata/promo-code-pc1.json
+++ b/v1/testdata/promo-code-pc1.json
@@ -1,0 +1,4 @@
+{
+  "promotion_code": "FREE_RIDEZ",
+  "description": "$20.00 off your next ride."
+}

--- a/v1/uber.go
+++ b/v1/uber.go
@@ -63,6 +63,13 @@ func (c *Client) SetHTTPRoundTripper(rt http.RoundTripper) {
 	c.Unlock()
 }
 
+func (c *Client) SetBearerToken(token string) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.token = token
+}
+
 func (c *Client) httpClient() *http.Client {
 	c.RLock()
 	rt := c.rt


### PR DESCRIPTION
Fixes #5.

Implemented methods to apply promo codes as well as
retrieve your profile.

Examples:

* ApplyPromoCode
```go
func applyPromoCode() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	appliedPromoCode, err := client.ApplyPromoCode("uberd340ue")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("AppliedPromoCode: %#v\n", appliedPromoCode)
}
```

* RetrieveMyProfile
```go

func retrieveMyProfile() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	myProfile, err := client.RetrieveMyProfile()
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Here is my profile: %#v\n", myProfile)
}
```