### PR TITLE
receipt: implement RequestReceipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,20 @@ func getTimeEstimates() {
 	}
 }
 ```
+
+* Retrieve a receipt
+```go
+func retrieveReceipt() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	receipt, err := client.RequestReceipt("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("That receipt: %#v\n", receipt)
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -210,3 +210,17 @@ func Example_client_ApplyPromoCode() {
 
 	fmt.Printf("AppliedPromoCode: %#v\n", appliedPromoCode)
 }
+
+func ExampleRequestReceipt() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	receipt, err := client.RequestReceipt("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("That receipt: %#v\n", receipt)
+}

--- a/v1/receipts.go
+++ b/v1/receipts.go
@@ -1,0 +1,82 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/orijtech/otils"
+)
+
+type Receipt struct {
+	// Unique identifier representing Request.
+	RequestID string `json:"request_id"`
+
+	// Subtotal = TotalFare - ChargeAdjustments
+	Subtotal otils.NullableString `json:"subtotal"`
+
+	// The fare after credits and refunds have been applied.
+	TotalFare otils.NullableString `json:"total_fare"`
+
+	// The total amount charged to the user's payment method.
+	// This is the subtotal (split if applicable) with taxes included.
+	TotalCharged otils.NullableString `json:"total_charged"`
+
+	// The total amount still owed after attempting to charge the
+	// user. May be null if amount was paid in full.
+	TotalOwed otils.NullableFloat64 `json:"total_owed"`
+
+	// The ISO 4217 currency code of the amounts.
+	CurrencyCode otils.NullableString `json:"currency_code"`
+
+	// Duration is the ISO 8601 HH:MM:SS
+	// format of the time duration of the trip.
+	Duration otils.NullableString `json:"currency_code"`
+
+	// Distance of the trip charged.
+	Distance otils.NullableString `json:"distance"`
+
+	// UnitOfDistance is the localized unit of distance.
+	UnitOfDistance otils.NullableString `json:"distance_label"`
+}
+
+var errEmptyReceiptID = errors.New("expecting a non-empty receiptID")
+
+func (c *Client) RequestReceipt(receiptID string) (*Receipt, error) {
+	if receiptID == "" {
+		return nil, errEmptyReceiptID
+	}
+
+	fullURL := fmt.Sprintf("%s/requests/%s/receipt", baseURL, receiptID)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	slurp, _, err := c.doAuthAndHTTPReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	receipt := new(Receipt)
+	if err := json.Unmarshal(slurp, receipt); err != nil {
+		return nil, err
+	}
+
+	return receipt, nil
+}

--- a/v1/testdata/receipt-b5512127-a134-4bf4-b1ba-fe9f48f56d9d.json
+++ b/v1/testdata/receipt-b5512127-a134-4bf4-b1ba-fe9f48f56d9d.json
@@ -1,0 +1,12 @@
+{
+  "request_id": "b5512127-a134-4bf4-b1ba-fe9f48f56d9d",
+  "subtotal": "$12.78",
+  "total_charged": "$5.92",
+  "total_owed": null,
+  "total_fare": "$5.92",
+  "currency_code": "USD",
+  "charge_adjustments": [],
+  "duration": "00:11:35",
+  "distance": "1.49",
+  "distance_label": "miles"
+}


### PR DESCRIPTION
Fixes #9.

Implement method RequestReceipt which takes in a requestID
that is retrieved from a trip history.

Sample usage
```go
func retrieveReceipt() {
        client, err := uber.NewClient()
        if err != nil {
                log.Fatal(err)
        }
        receipt, err :=
client.RequestReceipt("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
        if err != nil {
                log.Fatal(err)
        }

        fmt.Printf("That receipt: %#v\n", receipt)
}
```