### PR TITLE
uber: refactor leaky abstraction chan <-bool paradigm to func()

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func searchingForFirstEdmontonTrip() {
 		log.Fatal(err)
 	}
 
-	pagesChan, cancelChan, err := client.ListAllMyHistory()
+	pagesChan, cancelPaging, err := client.ListAllMyHistory()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func searchingForFirstEdmontonTrip() {
 			startCity := trip.StartCity
 			if startCity.Name == "Edmonton" {
 				fmt.Printf("aha found the trip from Edmonton, canceling the rest!: %#v\n", trip)
-				cancelChan <- true
+				cancelPaging()
 				break
 			}
 
@@ -117,7 +117,7 @@ func getPriceEstimates() {
 		log.Fatal(err)
 	}
 
-	estimatesPageChan, cancelChan, err := client.EstimatePrice(&uber.EstimateRequest{
+	estimatesPageChan, cancelPaging, err := client.EstimatePrice(&uber.EstimateRequest{
 		StartLatitude:  37.7752315,
 		EndLatitude:    37.7752415,
 		StartLongitude: -122.418075,
@@ -142,7 +142,7 @@ func getPriceEstimates() {
 		}
 
 		if itemCount >= 23 {
-			cancelChan <- true
+			cancelPaging()
 		}
 	}
 }
@@ -156,7 +156,7 @@ func getTimeEstimates() {
 		log.Fatal(err)
 	}
 
-	estimatesPageChan, cancelChan, err := client.EstimateTime(&uber.EstimateRequest{
+	estimatesPageChan, cancelPaging, err := client.EstimateTime(&uber.EstimateRequest{
 		StartLatitude:  37.7752315,
 		EndLatitude:    37.7752415,
 		StartLongitude: -122.418075,
@@ -183,7 +183,7 @@ func getTimeEstimates() {
 		}
 
 		if itemCount >= 23 {
-			cancelChan <- true
+			cancelPaging()
 		}
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -46,7 +46,7 @@ func Example_client_ListHistory() {
 		log.Fatal(err)
 	}
 
-	pagesChan, cancelChan, err := client.ListHistory(&uber.Pager{
+	pagesChan, cancelPaging, err := client.ListHistory(&uber.Pager{
 		MaxPages:     4,
 		LimitPerPage: 10,
 		StartOffset:  0,
@@ -67,7 +67,7 @@ func Example_client_ListHistory() {
 			startCity := trip.StartCity
 			if startCity.Name == "Tokyo" {
 				fmt.Printf("aha found the first Tokyo trip, canceling any more requests!: %#v\n", trip)
-				cancelChan <- true
+				cancelPaging()
 				break
 			}
 
@@ -83,7 +83,7 @@ func Example_client_ListAllMyHistory() {
 		log.Fatal(err)
 	}
 
-	pagesChan, cancelChan, err := client.ListAllMyHistory()
+	pagesChan, cancelPaging, err := client.ListAllMyHistory()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func Example_client_ListAllMyHistory() {
 			startCity := trip.StartCity
 			if startCity.Name == "Edmonton" {
 				fmt.Printf("aha found the trip from Edmonton, canceling the rest!: %#v\n", trip)
-				cancelChan <- true
+				cancelPaging()
 				break
 			}
 
@@ -115,7 +115,7 @@ func Example_client_EstimatePrice() {
 		log.Fatal(err)
 	}
 
-	estimatesPageChan, cancelChan, err := client.EstimatePrice(&uber.EstimateRequest{
+	estimatesPageChan, cancelPaging, err := client.EstimatePrice(&uber.EstimateRequest{
 		StartLatitude:  37.7752315,
 		EndLatitude:    37.7752415,
 		StartLongitude: -122.418075,
@@ -140,7 +140,7 @@ func Example_client_EstimatePrice() {
 		}
 
 		if itemCount >= 23 {
-			cancelChan <- true
+			cancelPaging()
 		}
 	}
 }
@@ -151,7 +151,7 @@ func Example_client_EstimateTime() {
 		log.Fatal(err)
 	}
 
-	estimatesPageChan, cancelChan, err := client.EstimateTime(&uber.EstimateRequest{
+	estimatesPageChan, cancelPaging, err := client.EstimateTime(&uber.EstimateRequest{
 		StartLatitude:  37.7752315,
 		EndLatitude:    37.7752415,
 		StartLongitude: -122.418075,
@@ -178,7 +178,7 @@ func Example_client_EstimateTime() {
 		}
 
 		if itemCount >= 23 {
-			cancelChan <- true
+			cancelPaging()
 		}
 	}
 }

--- a/v1/history.go
+++ b/v1/history.go
@@ -90,11 +90,11 @@ func (treq *Pager) adjustPageParams() {
 	}
 }
 
-func (c *Client) ListAllMyHistory() (chan *TripThreadPage, chan<- bool, error) {
+func (c *Client) ListAllMyHistory() (thChan chan *TripThreadPage, cancelFn func(), err error) {
 	return c.ListHistory(nil)
 }
 
-func (c *Client) ListHistory(threq *Pager) (chan *TripThreadPage, chan<- bool, error) {
+func (c *Client) ListHistory(threq *Pager) (thChan chan *TripThreadPage, cancelFn func(), err error) {
 	treq := new(Pager)
 	if threq != nil {
 		*treq = *threq
@@ -113,7 +113,8 @@ func (c *Client) ListHistory(threq *Pager) (chan *TripThreadPage, chan<- bool, e
 		return pageNumber >= uint64(requestedMaxPage)
 	}
 
-	cancelChan := make(chan bool, 1)
+	cancelChan, cancelFn := makeCancelParadigm()
+
 	historyChan := make(chan *TripThreadPage)
 	go func() {
 		defer close(historyChan)
@@ -183,5 +184,5 @@ func (c *Client) ListHistory(threq *Pager) (chan *TripThreadPage, chan<- bool, e
 		}
 	}()
 
-	return historyChan, cancelChan, nil
+	return historyChan, cancelFn, nil
 }

--- a/v1/prices.go
+++ b/v1/prices.go
@@ -87,7 +87,7 @@ type PriceEstimatesPage struct {
 	PageNumber uint64
 }
 
-func (c *Client) EstimatePrice(ereq *EstimateRequest) (chan *PriceEstimatesPage, chan bool, error) {
+func (c *Client) EstimatePrice(ereq *EstimateRequest) (pagesChan chan *PriceEstimatesPage, cancelPaging func(), err error) {
 	if ereq == nil {
 		return nil, nil, errNilEstimateRequest
 	}
@@ -110,7 +110,7 @@ func (c *Client) EstimatePrice(ereq *EstimateRequest) (chan *PriceEstimatesPage,
 		return pageNumber >= uint64(requestedMaxPage)
 	}
 
-	cancelChan := make(chan bool, 1)
+	cancelChan, cancelFn := makeCancelParadigm()
 	estimatesPageChan := make(chan *PriceEstimatesPage)
 	go func() {
 		defer close(estimatesPageChan)
@@ -180,5 +180,5 @@ func (c *Client) EstimatePrice(ereq *EstimateRequest) (chan *PriceEstimatesPage,
 		}
 	}()
 
-	return estimatesPageChan, cancelChan, nil
+	return estimatesPageChan, cancelFn, nil
 }

--- a/v1/times.go
+++ b/v1/times.go
@@ -58,7 +58,7 @@ var timeExcludedValues = map[string]bool{
 	"seat_count": true,
 }
 
-func (c *Client) EstimateTime(treq *EstimateRequest) (chan *TimeEstimatesPage, chan bool, error) {
+func (c *Client) EstimateTime(treq *EstimateRequest) (pagesChan chan *TimeEstimatesPage, cancelPaging func(), err error) {
 	if treq == nil {
 		return nil, nil, errNilTimeEstimateRequest
 	}
@@ -81,7 +81,7 @@ func (c *Client) EstimateTime(treq *EstimateRequest) (chan *TimeEstimatesPage, c
 		return pageNumber >= uint64(requestedMaxPage)
 	}
 
-	cancelChan := make(chan bool, 1)
+	cancelChan, cancelFn := makeCancelParadigm()
 	estimatesPageChan := make(chan *TimeEstimatesPage)
 	go func() {
 		defer close(estimatesPageChan)
@@ -151,5 +151,5 @@ func (c *Client) EstimateTime(treq *EstimateRequest) (chan *TimeEstimatesPage, c
 		}
 	}()
 
-	return estimatesPageChan, cancelChan, nil
+	return estimatesPageChan, cancelFn, nil
 }

--- a/v1/uber.go
+++ b/v1/uber.go
@@ -120,3 +120,15 @@ func (c *Client) doAuthAndHTTPReq(req *http.Request) ([]byte, http.Header, error
 	blob, err := ioutil.ReadAll(res.Body)
 	return blob, res.Header, err
 }
+
+func makeCancelParadigm() (<-chan bool, func()) {
+	var cancelOnce sync.Once
+	cancelChan := make(chan bool, 1)
+	cancelFn := func() {
+		cancelOnce.Do(func() {
+			close(cancelChan)
+		})
+	}
+
+	return cancelChan, cancelFn
+}

--- a/v1/uber_test.go
+++ b/v1/uber_test.go
@@ -117,7 +117,7 @@ func TestEstimatePrice(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		estimatesChan, cancelChan, err := client.EstimatePrice(tt.ereq)
+		estimatesChan, cancelPaging, err := client.EstimatePrice(tt.ereq)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("#%d expecting a non-nil error", i)
@@ -132,7 +132,7 @@ func TestEstimatePrice(t *testing.T) {
 
 		firstPage := <-estimatesChan
 		// Then cancel it
-		cancelChan <- true
+		cancelPaging()
 
 		if err := firstPage.Err; err != nil {
 			t.Errorf("#%d paging err: %v, firstPage: %#v", i, err, firstPage)
@@ -178,7 +178,7 @@ func TestEstimateTime(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		estimatesChan, cancelChan, err := client.EstimateTime(tt.treq)
+		estimatesChan, cancelPaging, err := client.EstimateTime(tt.treq)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("#%d expecting a non-nil error", i)
@@ -193,7 +193,7 @@ func TestEstimateTime(t *testing.T) {
 
 		firstPage := <-estimatesChan
 		// Then cancel it
-		cancelChan <- true
+		cancelPaging()
 
 		if err := firstPage.Err; err != nil {
 			t.Errorf("#%d paging err: %v, firstPage: %#v", i, err, firstPage)


### PR DESCRIPTION
Fixes #11.

The previous abstraction/paradigm for paging cancellation was
leaky and exposed too much information as well as a made it possible
for a user to screw up the program flow by closing the provided channel
or doing any operations on it.

The fix for this is to return a `func()` or cancelling function
that is invoked by the user whenever they need to cancel any paging.
This way the innards of the package can ensure that closing is only
called once and that the user doesn't have to think about channels.