### PR TITLE
places: implement retrieval of home + work

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,37 @@ func retrieveReceipt() {
 	fmt.Printf("That receipt: %#v\n", receipt)
 }
 ```
+
+* Retrieve your home address
+```go
+func retrieveMyHomeAddress() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	place, err := client.Place(uber.AddressHome)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("My home address: %#v\n", place.Address)
+}
+```
+
+* Retrieve your work address
+```go
+func retrieveMyWorkAddress() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	place, err := client.Place(uber.AddressWork)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("My work address: %#v\n", place.Address)
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -224,3 +224,31 @@ func ExampleRequestReceipt() {
 
 	fmt.Printf("That receipt: %#v\n", receipt)
 }
+
+func ExampleRetrieveHomeAddress() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	place, err := client.Place(uber.AddressHome)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("My home address: %#v\n", place.Address)
+}
+
+func ExampleRetrieveWorkAddress() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	place, err := client.Place(uber.AddressWork)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("My work address: %#v\n", place.Address)
+}

--- a/v1/history.go
+++ b/v1/history.go
@@ -54,6 +54,8 @@ type Place struct {
 
 	// The longitude of the approximate city center.
 	Longitude float64 `json:"longitude,omitempty"`
+
+	Address string `json:"address,omitempty"`
 }
 
 type TripThread struct {

--- a/v1/places.go
+++ b/v1/places.go
@@ -1,0 +1,46 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Address string
+
+const (
+	AddressHome Address = "home"
+	AddressWork Address = "work"
+)
+
+func (c *Client) Place(address Address) (*Place, error) {
+	fullURL := fmt.Sprintf("%s/places/%s", baseURL, address)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	slurp, _, err := c.doAuthAndHTTPReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	place := new(Place)
+	if err := json.Unmarshal(slurp, place); err != nil {
+		return nil, err
+	}
+	return place, nil
+}

--- a/v1/testdata/place-home
+++ b/v1/testdata/place-home
@@ -1,0 +1,3 @@
+{
+   "address": "685 Market St, San Francisco, CA 94103, USA"
+}

--- a/v1/testdata/place-work
+++ b/v1/testdata/place-work
@@ -1,0 +1,3 @@
+{
+   "address": "685 Market St, San Francisco, CA 94103, USA"
+}


### PR DESCRIPTION
Fixes #15.

One can now retrieve their home or work addresses just
as the Uber app shows.

Examples of how to retrieve your addresses:
* Retrieve your home address
```go
func retrieveMyHomeAddress() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	place, err := client.Place(uber.AddressHome)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("My home address: %#v\n", place.Address)
}
```

* Retrieve your work address
```go
func retrieveMyWorkAddress() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	place, err := client.Place(uber.AddressWork)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("My work address: %#v\n", place.Address)
}
```