### PR TITLE
maps: methods to Retrieve and Open maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,34 @@ func updateMyWorkAddress() {
 	fmt.Printf("My updated work address: %#v\n", updatedWork)
 }
 ```
+
+* Retrieve the map for a trip
+```go
+func requestMap() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tripMapInfo, err := client.RequestMap("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Visit the URL: %q for more information\n", tripMapInfo.URL)
+}
+```
+
+* Open the map for a trip in your web browser
+```go
+func openTheTripInBrowser() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := client.OpenMapForTrip("b5512127-a134-4bf4-b1ba-fe9f48f56d9d"); err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -211,7 +211,7 @@ func Example_client_ApplyPromoCode() {
 	fmt.Printf("AppliedPromoCode: %#v\n", appliedPromoCode)
 }
 
-func ExampleRequestReceipt() {
+func Example_client_RequestReceipt() {
 	client, err := uber.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -225,7 +225,7 @@ func ExampleRequestReceipt() {
 	fmt.Printf("That receipt: %#v\n", receipt)
 }
 
-func ExampleRetrieveHomeAddress() {
+func Example_client_RetrieveHomeAddress() {
 	client, err := uber.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -239,7 +239,7 @@ func ExampleRetrieveHomeAddress() {
 	fmt.Printf("My home address: %#v\n", place.Address)
 }
 
-func ExampleRetrieveWorkAddress() {
+func Example_client_RetrieveWorkAddress() {
 	client, err := uber.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -253,7 +253,7 @@ func ExampleRetrieveWorkAddress() {
 	fmt.Printf("My work address: %#v\n", place.Address)
 }
 
-func ExampleUpdateHomeAddress() {
+func Example_client_UpdateHomeAddress() {
 	client, err := uber.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -270,7 +270,7 @@ func ExampleUpdateHomeAddress() {
 	fmt.Printf("My updated home address: %#v\n", updatedHome)
 }
 
-func ExampleUpdateWorkAddress() {
+func Example_client_UpdateWorkAddress() {
 	client, err := uber.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -281,8 +281,33 @@ func ExampleUpdateWorkAddress() {
 		Address: "685 Market St, San Francisco, CA 94103, USA",
 	})
 	if err != nil {
-		log.Fatalf("work failed; %v", err)
+		log.Fatal(err)
 	}
 
 	fmt.Printf("My updated work address: %#v\n", updatedWork)
+}
+
+func Example_client_RequestMap() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tripMapInfo, err := client.RequestMap("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Visit the URL: %q for more information\n", tripMapInfo.URL)
+}
+
+func Example_client_OpenMap() {
+	client, err := uber.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := client.OpenMapForTrip("b5512127-a134-4bf4-b1ba-fe9f48f56d9d"); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/v1/maps.go
+++ b/v1/maps.go
@@ -1,0 +1,72 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/skratchdot/open-golang/open"
+)
+
+type Map struct {
+	RequestID string `json:"request_id"`
+
+	URL string `json:"href"`
+}
+
+var (
+	errEmptyTripID = errors.New("expecting a non-empty tripID")
+	errNoSuchMap   = errors.New("no such map")
+)
+
+func (c *Client) RequestMap(tripID string) (*Map, error) {
+	if tripID == "" {
+		return nil, errEmptyTripID
+	}
+
+	fullURL := fmt.Sprintf("%s/requests/%s/map", baseURL, tripID)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	slurp, _, err := c.doAuthAndHTTPReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	uinfo := new(Map)
+	blankMap := *uinfo
+	if err := json.Unmarshal(slurp, uinfo); err != nil {
+		return nil, err
+	}
+	if blankMap == *uinfo {
+		return nil, errNoSuchMap
+	}
+	return uinfo, nil
+}
+
+// OpenMapForTrip is a convenience method that opens the map
+// for a trip or returns an error if it encounters an error.
+func (c *Client) OpenMapForTrip(tripID string) error {
+	uinfo, err := c.RequestMap(tripID)
+	if err != nil {
+		return err
+	}
+	return open.Start(uinfo.URL)
+}

--- a/v1/testdata/map-b5512127-a134-4bf4-b1ba-fe9f48f56d9d.json
+++ b/v1/testdata/map-b5512127-a134-4bf4-b1ba-fe9f48f56d9d.json
@@ -1,0 +1,4 @@
+{
+  "request_id":"b5512127-a134-4bf4-b1ba-fe9f48f56d9d",
+  "href":"https://trip.uber.com/abc123"
+}


### PR DESCRIPTION
Fixes #19.

Allows:
* Retrieval of the map for a trip.
* Open up the map for a trip in your web browser.

- Exhibits:
* Retrieval of the map for a trip:
```go
func main() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	tripMapInfo, err := client.RequestMap("b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Visit the URL: %q for more information\n", tripMapInfo.URL)
}
```

* Open up the map for a trip in your web browser:
```go
func main() {
	client, err := uber.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	if err := client.OpenMapForTrip("b5512127-a134-4bf4-b1ba-fe9f48f56d9d"); err != nil {
		log.Fatal(err)
	}
}
```