### PR TITLE
oauth2: Allow Transport creation with Base

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -46,6 +46,12 @@ func Transport(token *oauth2.Token) *oauth2.Transport {
 	return &oauth2.Transport{Source: ts}
 }
 
+func TransportWithBase(token *oauth2.Token, base http.RoundTripper) *oauth2.Transport {
+	tr := Transport(token)
+	tr.Base = base
+	return tr
+}
+
 type tokenSourcer struct {
 	sync.RWMutex
 	token *oauth2.Token


### PR DESCRIPTION
Allow creation of an oauth2.0 Transport with a base
roundtripper. The purpose of this is to aid in testing
where we have a custom roundTripper and backend that
we hit instead of production, so calls never go over
the network.