### PR TITLE
prices: UpfrontFare implemented

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -311,3 +311,31 @@ func Example_client_OpenMap() {
 		log.Fatal(err)
 	}
 }
+
+func Example_client_UpfrontFare() {
+	client, err := uber.NewClientFromOAuth2File("./testdata/.uber/credentials.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	upfrontFare, err := client.UpfrontFare(&uber.EstimateRequest{
+		StartLatitude:  37.7752315,
+		EndLatitude:    37.7752415,
+		StartLongitude: -122.418075,
+		EndLongitude:   -122.518075,
+		SeatCount:      2,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if upfrontFare.SurgeInEffect() {
+		fmt.Printf("Surge is in effect!\n")
+		fmt.Printf("Please visit this URL to confirm %q then"+
+			"request again", upfrontFare.Estimate.SurgeConfirmationURL)
+		return
+	}
+
+	fmt.Printf("Fare: %#v\n", upfrontFare.Fare)
+	fmt.Printf("Trip: %#v\n", upfrontFare.Trip)
+}

--- a/v1/client.go
+++ b/v1/client.go
@@ -145,3 +145,11 @@ func NewClientFromOAuth2Token(token *oauth2.Token) (*Client, error) {
 	oauth2Transport := uberOAuth2.Transport(token)
 	return &Client{rt: oauth2Transport}, nil
 }
+
+func NewClientFromOAuth2File(tokenFilepath string) (*Client, error) {
+	oauth2Transport, err := uberOAuth2.TransportFromFile(tokenFilepath)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{rt: oauth2Transport}, nil
+}

--- a/v1/history.go
+++ b/v1/history.go
@@ -44,6 +44,11 @@ type Trip struct {
 
 	ProductID string `json:"product_id,omitempty"`
 	RequestID string `json:"request_id,omitempty"`
+
+	Unit string `json:"distance_unit,omitempty"`
+
+	DurationEstimate otils.NullableFloat64 `json:"duration_estimate,omitempty"`
+	DistanceEstimate otils.NullableFloat64 `json:"distance_estimate,omitempty"`
 }
 
 type Place struct {

--- a/v1/testdata/fare-estimate-no-surge.json
+++ b/v1/testdata/fare-estimate-no-surge.json
@@ -1,0 +1,15 @@
+{
+  "fare": {
+    "value": 5.73,
+    "fare_id": "d30e732b8bba22c9cdc10513ee86380087cb4a6f89e37ad21ba2a39f3a1ba960",
+    "expires_at": 1476953293,
+    "display": "$5.73",
+    "currency_code": "USD"
+  },
+  "trip": {
+    "distance_unit": "mile",
+    "duration_estimate": 540,
+    "distance_estimate": 2.39
+  },
+  "pickup_estimate": 2
+}

--- a/v1/testdata/fare-estimate-surge.json
+++ b/v1/testdata/fare-estimate-surge.json
@@ -1,0 +1,50 @@
+{
+  "estimate": {
+    "surge_confirmation_href": "https:\/\/api.uber.com\/v1\/surge-confirmations\/7d604f5e",
+    "high_estimate": 11,
+    "surge_confirmation_id": "7d604f5e",
+    "minimum": 5,
+    "low_estimate": 8,
+    "fare_breakdown": [
+      {
+        "low_amount": 1.25,
+        "high_amount": 1.25,
+        "display_amount": "1.25",
+        "display_name": "Base Fare"
+      },
+      {
+        "low_amount": 1.92,
+        "high_amount": 2.57,
+        "display_amount": "1.92-2.57",
+        "display_name": "Distance"
+      },
+      {
+        "low_amount": 2.50,
+        "high_amount": 3.50,
+        "display_amount": "2.50-3.50",
+        "display_name": "Surge x1.5"
+      },
+      {
+        "low_amount": 1.25,
+        "high_amount": 1.25,
+        "display_amount": "1.25",
+        "display_name": "Booking Fee"
+      },
+      {
+        "low_amount": 1.36,
+        "high_amount": 1.81,
+        "display_amount": "1.36-1.81",
+        "display_name": "Time"
+      }
+    ],
+    "surge_multiplier": 1.5,
+    "display": "$8-11",
+    "currency_code": "USD"
+  },
+  "trip": {
+    "distance_unit": "mile",
+    "duration_estimate": 480,
+    "distance_estimate": 1.95
+  },
+  "pickup_estimate": 2
+}


### PR DESCRIPTION
Fixes #24.

Allows retrieval of UpfrontFare that can give fareID
to enable requestin an Uber. Also implemented helpers
for retrieving OAuth2.0 transports and integrating them
into the client.

```go
func main() {
	client, err := uber.NewClientFromOAuth2File("./testdata/.uber/credentials.json")
	if err != nil {
		log.Fatal(err)
	}

	upfrontFare, err := client.UpfrontFare(&uber.EstimateRequest{
		StartLatitude:  37.7752315,
		EndLatitude:    37.7752415,
		StartLongitude: -122.418075,
		EndLongitude:   -122.518075,
		SeatCount:      2,
	})
	if err != nil {
		log.Fatal(err)
	}

        if upfrontFare.SurgeInEffect() {
                fmt.Printf("Surge is in effect!\n")
                fmt.Printf("Please visit this URL to confirm %q then"+
                           "request again", upfrontFare.Estimate.SurgeConfirmationURL)
                return
        }

        fmt.Printf("FareID: %s\n", upfrontFare.Fare.ID)
	fmt.Printf("Fare: %#v\n", upfrontFare.Fare)
	fmt.Printf("FareEstimate: %#v\n", upfrontFare.Estimate)
	fmt.Printf("Trip: %#v\n", upfrontFare.Trip)
}
```