### PR TITLE
deliveries: implemented client.CancelDelivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,3 +396,20 @@ func requestDelivery() {
 	log.Printf("The confirmation: %+v\n", deliveryConfirmation)
 }
 ```
+
+* Cancel a delivery
+```go
+func cancelDelivery() {
+	client, err := uber.NewClientFromOAuth2File("./testdata/.uber/credentials.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err := client.CancelDelivery("71a969ca-5359-4334-a7b7-5a1705869c51")
+	if err == nil {
+		log.Printf("Successfully canceled that delivery!")
+	} else {
+		log.Printf("Failed to cancel that delivery, err: %v", err)
+	}
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -419,3 +419,17 @@ func Example_client_RequestDelivery() {
 
 	log.Printf("The confirmation: %+v\n", deliveryConfirmation)
 }
+
+func Example_client_CancelDelivery() {
+	client, err := uber.NewClientFromOAuth2File("./testdata/.uber/credentials.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err := client.CancelDelivery("71a969ca-5359-4334-a7b7-5a1705869c51")
+	if err == nil {
+		log.Printf("Successfully canceled that delivery!")
+	} else {
+		log.Printf("Failed to cancel that delivery, err: %v", err)
+	}
+}

--- a/v1/deliveries.go
+++ b/v1/deliveries.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/orijtech/otils"
 )
@@ -210,7 +211,7 @@ func (c *Client) RequestDelivery(req *DeliveryRequest) (*DeliveryResponse, error
 		return nil, err
 	}
 
-	blob, _, err = c.doAuthAndHTTPReq(httpReq)
+	blob, _, err = c.doHTTPReq(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -219,4 +220,23 @@ func (c *Client) RequestDelivery(req *DeliveryRequest) (*DeliveryResponse, error
 		return nil, err
 	}
 	return dRes, nil
+}
+
+var errBlankDeliveryID = errors.New("expecting a non-blank deliveryID")
+
+// CancelDelivery cancels a delivery referenced by its ID. There are
+// potential cancellation fees associated.
+// See https://developer.uber.com/docs/deliveries/faq for more information.
+func (c *Client) CancelDelivery(deliveryID string) error {
+	deliveryID = strings.TrimSpace(deliveryID)
+	if deliveryID == "" {
+		return errBlankDeliveryID
+	}
+	theURL := fmt.Sprintf("%s/deliveries/%s/cancel", c.baseURL(), deliveryID)
+	httpReq, err := http.NewRequest("POST", theURL, nil)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.doHTTPReq(httpReq)
+	return err
 }

--- a/v1/rides.go
+++ b/v1/rides.go
@@ -158,7 +158,7 @@ func (c *Client) RequestRide(rreq *RideRequest) (*Ride, error) {
 	if err != nil {
 		return nil, err
 	}
-	blob, _, err = c.doAuthAndHTTPReq(req)
+	blob, _, err = c.doHTTPReq(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates #32

Cancel a delivery by means of the delivery ID.
There are limitations however on when a cancellation
can be made. See more information at
https://developer.uber.com/docs/deliveries/references/api/v1/deliveries-delivery_id-cancel-post

* Exhibit:
```go
func cancelDelivery() {
	client, err := uber.NewClientFromOAuth2File("./testdata/.uber/credentials.json")
	if err != nil {
		log.Fatal(err)
	}

	err := client.CancelDelivery("71a969ca-5359-4334-a7b7-5a1705869c51")
	if err == nil {
		log.Printf("Successfully canceled that delivery!")
	} else {
		log.Printf("Failed to cancel that delivery, err: %v", err)
	}
}
```