### PR TITLE
delivery: implemented Client.ListDeliveries

### DIFF
--- a/cmd/uber/main.go
+++ b/cmd/uber/main.go
@@ -47,7 +47,7 @@ func authorize() {
 	scopes := []string{
 		oauth2.ScopeProfile, oauth2.ScopeRequest,
 		oauth2.ScopeHistory, oauth2.ScopePlaces,
-		oauth2.ScopeRequestReceipt,
+		oauth2.ScopeRequestReceipt, oauth2.ScopeDelivery,
 	}
 
 	token, err := oauth2.AuthorizeByEnvApp(scopes...)

--- a/example_test.go
+++ b/example_test.go
@@ -144,8 +144,6 @@ func Example_client_EstimatePrice() {
 			cancelPaging()
 		}
 	}
-// Output:
-// WW
 }
 
 func Example_client_EstimateTime() {
@@ -184,8 +182,6 @@ func Example_client_EstimateTime() {
 			cancelPaging()
 		}
 	}
-// Output:
-// WW
 }
 
 func Example_client_RetrieveMyProfile() {
@@ -456,8 +452,6 @@ func Example_client_ListProducts() {
 	for i, product := range products {
 		fmt.Printf("#%d: ID: %q Product: %#v\n", i, product.ID, product)
 	}
-// Output:
-// WW
 }
 
 func Example_client_ProductByID() {
@@ -472,4 +466,33 @@ func Example_client_ProductByID() {
 	}
 
 	fmt.Printf("The Product information: %#v\n", product)
+}
+
+func Example_client_ListDeliveries() {
+	client, err := uber.NewClientFromOAuth2File(os.ExpandEnv("$HOME/.uber/credentials.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	delivRes, err := client.ListDeliveries(&uber.DeliveryListRequest{
+		Status:      uber.StatusCompleted,
+		StartOffset: 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	itemCount := uint64(0)
+	for page := range delivRes.Pages {
+		if page.Err != nil {
+			fmt.Printf("Page #%d err: %v", page.PageNumber, page.Err)
+		}
+		for i, delivery := range page.Deliveries {
+			fmt.Printf("\t(%d): %#v\n", i, delivery)
+			itemCount += 1
+		}
+		if itemCount >= 10 {
+			delivRes.Cancel()
+		}
+	}
 }

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -177,6 +177,10 @@ const (
 	// including pickup, destination and real-time
 	// location for all of your future rides.
 	ScopeAllTrips = "all_trips"
+
+	// ScopeDelivery is a privileged scope that gives
+	// access to the authenticated user's deliveries.
+	ScopeDelivery = "delivery"
 )
 
 func AuthorizeByEnvApp(scopes ...string) (*oauth2.Token, error) {

--- a/v1/client.go
+++ b/v1/client.go
@@ -80,6 +80,22 @@ func (c *Client) baseURL() string {
 	}
 }
 
+// Some endpoints require us to hit /v1 instead of /v1.2 as in Client.baseURL.
+// These endpoints include:
+// + ListDeliveries --> /v1/deliveries at least as of "Tue  4 Jul 2017 23:17:14 MDT"
+func (c *Client) legacyV1BaseURL() string {
+	// Setting the baseURLs in here to ensure that no-one mistakenly
+	// directly invokes baseURL or sandboxBaseURL.
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.sandboxed {
+		return "https://sandbox-api.uber.com/v1"
+	} else { // Invoking the production endpoint
+		return "https://api.uber.com/v1"
+	}
+}
+
 func NewClient(tokens ...string) (*Client, error) {
 	if token := otils.FirstNonEmptyString(tokens...); token != "" {
 		return &Client{token: token}, nil


### PR DESCRIPTION
Updates #32

* Implemented Client.ListDeliveries.
* Introduced scope oauth2.ScopeDelivery.

NB:
* ListDeliveries hits the /v1 API instead of
/v1.2

Sample usage:
```go
func main() {
	client, err := uber.NewClientFromOAuth2File(os.ExpandEnv("$HOME/.uber/credentials.json"))
	if err != nil {
		log.Fatal(err)
	}

	delivRes, err := client.ListDeliveries(&uber.DeliveryListRequest{
		Status:      uber.StatusCompleted,
		StartOffset: 20,
	})
	if err != nil {
		log.Fatal(err)
	}

	itemCount := uint64(0)
	for page := range delivRes.Pages {
		if page.Err != nil {
			fmt.Printf("Page #%d err: %v", page.PageNumber, page.Err)
		}
		for i, delivery := range page.Deliveries {
			fmt.Printf("\t(%d): %#v\n", i, delivery)
			itemCount += 1
		}
		if itemCount >= 10 {
			delivRes.Cancel()
		}
	}
}
```