### PR TITLE
README: Fix const names in places examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ func retrieveMyHomeAddress() {
 		log.Fatal(err)
 	}
 
-	place, err := client.Place(uber.AddressHome)
+	place, err := client.Place(uber.PlaceHome)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func retrieveMyWorkAddress() {
 		log.Fatal(err)
 	}
 
-	place, err := client.Place(uber.AddressWork)
+	place, err := client.Place(uber.PlaceWork)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Examples of retrieving home & work addresses doesn't to compile:
```bash
$ build example.go
./example.go:15:29: undefined: uber.AddressHome
```

Replace const names:
- `uber.AddressHome` -> `uber.PlaceHome`
- `uber.AddressWork` -> `uber.PlaceWork`